### PR TITLE
Fix -fallow-argument-mismatch in clEnqueue(Read|Write)BufferImpl

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,76 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: ubuntu-latest
+        - os: macos-12 # macos-latest is arm64 without OpenCL
+
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            clinfo gfortran ocl-icd-opencl-dev pocl-opencl-icd
+
+      # https://github.com/pocl/pocl/issues/1049
+      # https://github.com/joanbm/lib842/blob/a82d393/.github/workflows/build-and-test.yml#L65
+      - name: Fix POCL
+        if: runner.os == 'Linux'
+        run: |
+          cat << EOF > pocl-hack.c
+          #include <stddef.h>
+          struct FakeStringRef {
+            const char *data;
+            size_t len;
+          };
+          struct FakeStringRef _ZN4llvm3sys14getHostCPUNameEv() {
+            return (struct FakeStringRef){ .data = "x86-64", .len = 6 };
+          }
+          EOF
+
+          cc pocl-hack.c -fPIC -shared -o pocl-hack.so
+          echo "LD_PRELOAD=$PWD/pocl-hack.so" >> $GITHUB_ENV
+          rm pocl-hack.c
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: |
+          brew install \
+            automake clinfo gcc@13
+          echo "FC=gfortran-13" >> $GITHUB_ENV
+
+      - name: OpenCL platforms and devices
+        run: clinfo
+
+      - name: Configure
+        run: |
+          autoreconf -i
+          ./configure
+        env:
+          FCFLAGS: "-fallow-argument-mismatch"
+
+      - name: Build
+        run: make -e -j 2
+
+      - name: Test
+        run: |
+          make -e -j 2 check || {
+            cat testsuite/test-suite.log
+            false
+          }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,6 @@ jobs:
         run: |
           autoreconf -i
           ./configure
-        env:
-          FCFLAGS: "-fallow-argument-mismatch"
 
       - name: Build
         run: make -e -j 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-        - os: macos-12 # macos-latest is arm64 without OpenCL
+        # - os: macos-latest
 
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -52,8 +52,8 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install \
-            automake clinfo gcc@13
-          echo "FC=gfortran-13" >> $GITHUB_ENV
+            automake clinfo gcc@14 pocl
+          echo "FC=gfortran-14" >> $GITHUB_ENV
 
       - name: OpenCL platforms and devices
         run: clinfo

--- a/src/cl_command_queue.f90
+++ b/src/cl_command_queue.f90
@@ -33,32 +33,32 @@ module cl_command_queue_m
     clFinish,                        &
     clFlush
   
-  ! The following functions are not declared since they are
-  ! polymorphic beyond the capabilities of Fortran. They can be
-  ! called, but no type checking will be done by the compiler.
-  
-  !  interface
-  !    subroutine clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
-  !      type(cl_command_queue), intent(inout) :: command_queue
-  !      type(cl_mem),           intent(inout) :: buffer
-  !      integer,                intent(in)    :: blocking_write
-  !      integer(8),             intent(in)    :: offset
-  !      integer(8),             intent(in)    :: cb
-  !      type(any),              intent(inout) :: ptr
-  !      integer,                intent(out)   :: errcode_ret
-  !    end subroutine clEnqueueWriteBufferImpl
-  
-  !    subroutine clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
-  !      type(cl_command_queue), intent(inout) :: command_queue
-  !      type(cl_mem),           intent(inout) :: buffer
-  !      integer,                intent(in)    :: blocking_write
-  !      integer(8),             intent(in)    :: offset
-  !      integer(8),             intent(in)    :: cb
-  !      type(any),              intent(inout) :: ptr
-  !      integer,                intent(out)   :: errcode_ret
-  !    end subroutine clEnqueueReadBufferImpl
-  
-  !  end interface
+  interface
+    subroutine clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+      use iso_c_binding, only: c_ptr
+      use cl_types_m
+      type(cl_command_queue), intent(inout) :: command_queue
+      type(cl_mem),           intent(inout) :: buffer
+      integer,                intent(in)    :: blocking_write
+      integer(8),             intent(in)    :: offset
+      integer(8),             intent(in)    :: cb
+      type(c_ptr), value,     intent(in)    :: ptr
+      integer,                intent(out)   :: errcode_ret
+    end subroutine clEnqueueWriteBufferImpl
+
+    subroutine clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+      use iso_c_binding, only: c_ptr
+      use cl_types_m
+      type(cl_command_queue), intent(inout) :: command_queue
+      type(cl_mem),           intent(in)    :: buffer
+      integer,                intent(in)    :: blocking_write
+      integer(8),             intent(in)    :: offset
+      integer(8),             intent(in)    :: cb
+      type(c_ptr), value,     intent(in)    :: ptr
+      integer,                intent(out)   :: errcode_ret
+    end subroutine clEnqueueReadBufferImpl
+
+  end interface
 
   ! ----------------------------------------------------
 
@@ -244,210 +244,224 @@ contains
   ! ---------------------------------------
 
   subroutine clEnqueueWriteBuffer_integer4(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(inout) :: buffer
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    integer(4),             intent(in)    :: ptr
+    integer(4), target,     intent(in)    :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueWriteBuffer_integer4
 
   ! ---------------------------------------
 
   subroutine clEnqueueWriteBuffer_integer8(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(inout) :: buffer
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    integer(8),             intent(in)    :: ptr
+    integer(8), target,     intent(in)    :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueWriteBuffer_integer8
 
   ! ---------------------------------------
 
   subroutine clEnqueueWriteBuffer_real4(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(inout) :: buffer
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    real(4),                intent(in)    :: ptr
+    real(4), target,        intent(in)    :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueWriteBuffer_real4
 
   ! ---------------------------------------
 
   subroutine clEnqueueWriteBuffer_real8(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(inout) :: buffer
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    real(8),                intent(in)    :: ptr
+    real(8),    target,     intent(in)    :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueWriteBuffer_real8
 
   ! ---------------------------------------
 
   subroutine clEnqueueWriteBuffer_complex4(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(inout) :: buffer
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    complex(4),             intent(in)    :: ptr
+    complex(4), target,     intent(in)    :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueWriteBuffer_complex4
 
   ! ---------------------------------------
 
   subroutine clEnqueueWriteBuffer_complex8(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(inout) :: buffer
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    complex(8),             intent(in)    :: ptr
+    complex(8), target,     intent(in)    :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueWriteBuffer_complex8
 
   ! ---------------------------------------
 
   subroutine clEnqueueWriteBuffer_character(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(inout) :: buffer
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    character,              intent(in)    :: ptr
+    character, target,      intent(in)    :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueWriteBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueWriteBuffer_character
 
   ! ---------------------------------------
 
   subroutine clEnqueueReadBuffer_integer4(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(in)    :: buffer 
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    integer(4),             intent(out)   :: ptr
+    integer(4), target,     intent(out)   :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueReadBuffer_integer4
 
   ! ---------------------------------------
 
   subroutine clEnqueueReadBuffer_integer8(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(in)    :: buffer 
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    integer(8),             intent(out)   :: ptr
+    integer(8), target,     intent(out)   :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueReadBuffer_integer8
 
   ! ---------------------------------------
 
   subroutine clEnqueueReadBuffer_real4(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(in)    :: buffer 
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    real(4),                intent(out)   :: ptr
+    real(4), target,        intent(out)   :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueReadBuffer_real4
 
   ! ---------------------------------------
 
   subroutine clEnqueueReadBuffer_real8(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(in)    :: buffer 
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    real(8),                intent(out)   :: ptr
+    real(8), target,        intent(out)   :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueReadBuffer_real8
 
   ! ---------------------------------------
 
   subroutine clEnqueueReadBuffer_complex4(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(in)    :: buffer
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    complex(4),             intent(out)   :: ptr
+    complex(4), target,     intent(out)   :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueReadBuffer_complex4
 
   ! ---------------------------------------
 
   subroutine clEnqueueReadBuffer_complex8(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(in)    :: buffer
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    complex(8),             intent(out)   :: ptr
+    complex(8), target,     intent(out)   :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueReadBuffer_complex8
 
   ! ---------------------------------------
 
   subroutine clEnqueueReadBuffer_character(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    use iso_c_binding, only: c_loc
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(in)    :: buffer
     integer,                intent(in)    :: blocking_write
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
-    character,              intent(out)   :: ptr
+    character, target,      intent(out)   :: ptr
     integer,                intent(out)   :: errcode_ret
     
-    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, ptr, errcode_ret)
+    call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueReadBuffer_character
 

--- a/src/cl_command_queue.f90
+++ b/src/cl_command_queue.f90
@@ -498,7 +498,7 @@ contains
     use iso_c_binding, only: c_loc, c_sizeof
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(in)    :: buffer
-    integer(1), target,     intent(out)   :: ptr
+    integer(1), target,     intent(in)    :: ptr
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
     integer,                intent(out)   :: errcode_ret
@@ -513,7 +513,7 @@ contains
     use iso_c_binding, only: c_loc, c_sizeof
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(in)    :: buffer
-    integer(2), target,     intent(out)   :: ptr
+    integer(2), target,     intent(in)    :: ptr
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
     integer,                intent(out)   :: errcode_ret
@@ -528,7 +528,7 @@ contains
     use iso_c_binding, only: c_loc, c_sizeof
     type(cl_command_queue), intent(inout) :: command_queue
     type(cl_mem),           intent(in)    :: buffer
-    integer(4), target,     intent(out)   :: ptr
+    integer(4), target,     intent(in)    :: ptr
     integer(8),             intent(in)    :: offset
     integer(8),             intent(in)    :: cb
     integer,                intent(out)   :: errcode_ret

--- a/src/cl_command_queue.f90
+++ b/src/cl_command_queue.f90
@@ -30,6 +30,7 @@ module cl_command_queue_m
     clEnqueueNDRangeKernel,          &
     clEnqueueWriteBuffer,            &
     clEnqueueReadBuffer,             &
+    clEnqueueFillBuffer,             &
     clFinish,                        &
     clFlush
   
@@ -57,6 +58,18 @@ module cl_command_queue_m
       type(c_ptr), value,     intent(in)    :: ptr
       integer,                intent(out)   :: errcode_ret
     end subroutine clEnqueueReadBufferImpl
+
+    subroutine clEnqueueFillBufferImpl(command_queue, buffer, pattern, pattern_size, offset, cb, errcode_ret)
+      use iso_c_binding, only: c_ptr
+      use cl_types_m
+      type(cl_command_queue), intent(inout) :: command_queue
+      type(cl_mem),           intent(in)    :: buffer
+      type(c_ptr), value,     intent(in)    :: pattern
+      integer(8),             intent(in)    :: pattern_size
+      integer(8),             intent(in)    :: offset
+      integer(8),             intent(in)    :: cb
+      integer,                intent(out)   :: errcode_ret
+    end subroutine clEnqueueFillBufferImpl
 
   end interface
 
@@ -157,7 +170,19 @@ module cl_command_queue_m
     module procedure clEnqueueReadBuffer_complex8
     module procedure clEnqueueReadBuffer_character
   end interface clEnqueueReadBuffer
-  
+
+  ! ---------------------------------------------------
+
+  interface clEnqueueFillBuffer
+    module procedure clEnqueueFillBuffer_integer4
+    module procedure clEnqueueFillBuffer_integer8
+    module procedure clEnqueueFillBuffer_real4
+    module procedure clEnqueueFillBuffer_real8
+    module procedure clEnqueueFillBuffer_complex4
+    module procedure clEnqueueFillBuffer_complex8
+    module procedure clEnqueueFillBuffer_character
+  end interface clEnqueueFillBuffer
+
   interface
     subroutine clEnqueueNDRangeKernel_low(command_queue, kernel, work_dim, globalsizes, localsizes, event, errcode_ret)
       use cl_types_m
@@ -464,6 +489,111 @@ contains
     call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueReadBuffer_character
+
+  ! ---------------------------------------
+
+  subroutine clEnqueueFillBuffer_integer4(command_queue, buffer, ptr, offset, cb, errcode_ret)
+    use iso_c_binding, only: c_loc, c_sizeof
+    type(cl_command_queue), intent(inout) :: command_queue
+    type(cl_mem),           intent(in)    :: buffer
+    integer(4), target,     intent(out)   :: ptr
+    integer(8),             intent(in)    :: offset
+    integer(8),             intent(in)    :: cb
+    integer,                intent(out)   :: errcode_ret
+
+    call clEnqueueFillBufferImpl(command_queue, buffer, c_loc(ptr), c_sizeof(ptr), offset, cb, errcode_ret)
+
+  end subroutine clEnqueueFillBuffer_integer4
+
+  ! ---------------------------------------
+
+  subroutine clEnqueueFillBuffer_integer8(command_queue, buffer, ptr, offset, cb, errcode_ret)
+    use iso_c_binding, only: c_loc, c_sizeof
+    type(cl_command_queue), intent(inout) :: command_queue
+    type(cl_mem),           intent(in)    :: buffer
+    integer(8), target,     intent(in)    :: ptr
+    integer(8),             intent(in)    :: offset
+    integer(8),             intent(in)    :: cb
+    integer,                intent(out)   :: errcode_ret
+
+    call clEnqueueFillBufferImpl(command_queue, buffer, c_loc(ptr), c_sizeof(ptr), offset, cb, errcode_ret)
+
+  end subroutine clEnqueueFillBuffer_integer8
+
+  ! ---------------------------------------
+
+  subroutine clEnqueueFillBuffer_real4(command_queue, buffer, ptr, offset, cb, errcode_ret)
+    use iso_c_binding, only: c_loc, c_sizeof
+    type(cl_command_queue), intent(inout) :: command_queue
+    type(cl_mem),           intent(in)    :: buffer
+    real(4), target,        intent(in)    :: ptr
+    integer(8),             intent(in)    :: offset
+    integer(8),             intent(in)    :: cb
+    integer,                intent(out)   :: errcode_ret
+
+    call clEnqueueFillBufferImpl(command_queue, buffer, c_loc(ptr), c_sizeof(ptr), offset, cb, errcode_ret)
+
+  end subroutine clEnqueueFillBuffer_real4
+
+  ! ---------------------------------------
+
+  subroutine clEnqueueFillBuffer_real8(command_queue, buffer, ptr, offset, cb, errcode_ret)
+    use iso_c_binding, only: c_loc, c_sizeof
+    type(cl_command_queue), intent(inout) :: command_queue
+    type(cl_mem),           intent(in)    :: buffer
+    real(8), target,        intent(in)    :: ptr
+    integer(8),             intent(in)    :: offset
+    integer(8),             intent(in)    :: cb
+    integer,                intent(out)   :: errcode_ret
+
+    call clEnqueueFillBufferImpl(command_queue, buffer, c_loc(ptr), c_sizeof(ptr), offset, cb, errcode_ret)
+
+  end subroutine clEnqueueFillBuffer_real8
+
+  ! ---------------------------------------
+
+  subroutine clEnqueueFillBuffer_complex4(command_queue, buffer, ptr, offset, cb, errcode_ret)
+    use iso_c_binding, only: c_loc, c_sizeof
+    type(cl_command_queue), intent(inout) :: command_queue
+    type(cl_mem),           intent(in)    :: buffer
+    complex(4), target,     intent(in)    :: ptr
+    integer(8),             intent(in)    :: offset
+    integer(8),             intent(in)    :: cb
+    integer,                intent(out)   :: errcode_ret
+
+    call clEnqueueFillBufferImpl(command_queue, buffer, c_loc(ptr), c_sizeof(ptr), offset, cb, errcode_ret)
+
+  end subroutine clEnqueueFillBuffer_complex4
+
+  ! ---------------------------------------
+
+  subroutine clEnqueueFillBuffer_complex8(command_queue, buffer, ptr, offset, cb, errcode_ret)
+    use iso_c_binding, only: c_loc, c_sizeof
+    type(cl_command_queue), intent(inout) :: command_queue
+    type(cl_mem),           intent(in)    :: buffer
+    complex(8), target,     intent(in)    :: ptr
+    integer(8),             intent(in)    :: offset
+    integer(8),             intent(in)    :: cb
+    integer,                intent(out)   :: errcode_ret
+
+    call clEnqueueFillBufferImpl(command_queue, buffer, c_loc(ptr), c_sizeof(ptr), offset, cb, errcode_ret)
+
+  end subroutine clEnqueueFillBuffer_complex8
+
+  ! ---------------------------------------
+
+  subroutine clEnqueueFillBuffer_character(command_queue, buffer, ptr, offset, cb, errcode_ret)
+    use iso_c_binding, only: c_loc, c_sizeof
+    type(cl_command_queue), intent(inout) :: command_queue
+    type(cl_mem),           intent(in)    :: buffer
+    character, target,      intent(in)    :: ptr
+    integer(8),             intent(in)    :: offset
+    integer(8),             intent(in)    :: cb
+    integer,                intent(out)   :: errcode_ret
+
+    call clEnqueueFillBufferImpl(command_queue, buffer, c_loc(ptr), c_sizeof(ptr), offset, cb, errcode_ret)
+
+  end subroutine clEnqueueFillBuffer_character
 
   ! ---------------------------------------
 

--- a/src/cl_command_queue.f90
+++ b/src/cl_command_queue.f90
@@ -174,6 +174,8 @@ module cl_command_queue_m
   ! ---------------------------------------------------
 
   interface clEnqueueFillBuffer
+    module procedure clEnqueueFillBuffer_integer1
+    module procedure clEnqueueFillBuffer_integer2
     module procedure clEnqueueFillBuffer_integer4
     module procedure clEnqueueFillBuffer_integer8
     module procedure clEnqueueFillBuffer_real4
@@ -489,6 +491,36 @@ contains
     call clEnqueueReadBufferImpl(command_queue, buffer, blocking_write, offset, cb, c_loc(ptr), errcode_ret)
 
   end subroutine clEnqueueReadBuffer_character
+
+  ! ---------------------------------------
+
+  subroutine clEnqueueFillBuffer_integer1(command_queue, buffer, ptr, offset, cb, errcode_ret)
+    use iso_c_binding, only: c_loc, c_sizeof
+    type(cl_command_queue), intent(inout) :: command_queue
+    type(cl_mem),           intent(in)    :: buffer
+    integer(1), target,     intent(out)   :: ptr
+    integer(8),             intent(in)    :: offset
+    integer(8),             intent(in)    :: cb
+    integer,                intent(out)   :: errcode_ret
+
+    call clEnqueueFillBufferImpl(command_queue, buffer, c_loc(ptr), c_sizeof(ptr), offset, cb, errcode_ret)
+
+  end subroutine clEnqueueFillBuffer_integer1
+
+  ! ---------------------------------------
+
+  subroutine clEnqueueFillBuffer_integer2(command_queue, buffer, ptr, offset, cb, errcode_ret)
+    use iso_c_binding, only: c_loc, c_sizeof
+    type(cl_command_queue), intent(inout) :: command_queue
+    type(cl_mem),           intent(in)    :: buffer
+    integer(2), target,     intent(out)   :: ptr
+    integer(8),             intent(in)    :: offset
+    integer(8),             intent(in)    :: cb
+    integer,                intent(out)   :: errcode_ret
+
+    call clEnqueueFillBufferImpl(command_queue, buffer, c_loc(ptr), c_sizeof(ptr), offset, cb, errcode_ret)
+
+  end subroutine clEnqueueFillBuffer_integer2
 
   ! ---------------------------------------
 

--- a/src/cl_command_queue_low.c
+++ b/src/cl_command_queue_low.c
@@ -103,3 +103,11 @@ void FC_FUNC(clenqueuereadbufferimpl, CLENQUEUEREADBUFFERIMPL)
 				      (size_t) *offset, (size_t) *cb, ptr, 0, NULL, NULL);
 }
 
+/* -----------------------------------------------------------------------*/
+
+void FC_FUNC(clenqueuefillbufferimpl, CLENQUEUEFILLBUFFERIMPL)
+     (cl_command_queue * command_queue, cl_mem * buffer, const void * pattern, const cl_long * pattern_size,
+      const cl_long * offset, const cl_long * cb, int * status){
+    *status = (int) clEnqueueFillBuffer(*command_queue, *buffer, pattern, (size_t) *pattern_size,
+                                        (size_t) *offset, (size_t) *cb, 0, NULL, NULL);
+}

--- a/src/cl_device.f90
+++ b/src/cl_device.f90
@@ -121,7 +121,7 @@ module cl_device_m
       
       type(cl_platform_id), intent(in)   :: platform
       integer,              intent(in)   :: device_type
-      integer,              intent(out)  :: num_entries
+      integer,              intent(in)   :: num_entries
       type(cl_device_id),   intent(out)  :: devices
       integer,              intent(out)  :: num_devices
       integer,              intent(out)  :: errcode_ret

--- a/src/cl_event_low.c
+++ b/src/cl_event_low.c
@@ -36,7 +36,7 @@ void FC_FUNC_(clretainevent_low, CLRETAINEVENT_LOW)(cl_event * event, int * stat
 
 /* -----------------------------------------------------------------------*/
 
-void FC_FUNC_(clwaitforevents_low, CLWAITFOREVENTS_ARRAY_LOW)
+void FC_FUNC_(clwaitforevents_low, CLWAITFOREVENTS_LOW)
      (const int * numevents, const cl_event * event, int * status){
 
   *status = (int)clWaitForEvents(*numevents, event);

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -34,7 +34,7 @@ char_LDADD = $(top_builddir)/src/libfortrancl.la @CL_LIBS@
 queue_SOURCES = queue.f90 $(UTILS)
 queue_LDADD = $(top_builddir)/src/libfortrancl.la @CL_LIBS@
 
-devices_SOURCES = devices.f90
+devices_SOURCES = devices.f90 $(UTILS)
 devices_LDADD = $(top_builddir)/src/libfortrancl.la @CL_LIBS@
 
 AM_FCFLAGS = @F90_MODULE_FLAG@$(top_builddir)/src
@@ -44,3 +44,4 @@ CLEANFILES = *~ *.bak *.mod *.MOD *.il *.d *.pc* ifc* $(noinst_PROGRAMS)
 sum.o : sum.f90 $(UTILS_O)
 char.o : char.f90 $(UTILS_O)
 queue.o : queue.f90 $(UTILS_O)
+devices.o : devices.f90 $(UTILS_O)

--- a/testsuite/char.f90
+++ b/testsuite/char.f90
@@ -30,7 +30,7 @@ program char
   integer    :: size, ierr
   integer(8) :: size_in_bytes, globalsize, localsize
   type(cl_mem)        :: cl_string
-  integer, parameter  :: string_length = 1024
+  integer, parameter  :: string_length = 4096
   character(len=string_length) :: string1, string2
 
   call initialize(device, context, command_queue)

--- a/testsuite/char.f90
+++ b/testsuite/char.f90
@@ -43,25 +43,34 @@ program char
   size_in_bytes = int(string_length, 8)
 
   cl_string = clCreateBuffer(context, CL_MEM_READ_ONLY, size_in_bytes, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clCreateBuffer.', ierr)
 
   string1 = 'Pepper clemens sent the messenger nevertheless the reverend left the herd'
   print*, trim(string1)
 
   call clEnqueueWriteBuffer(command_queue, cl_string, cl_bool(.true.), 0_8, size_in_bytes, string1(1:1), ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueWriteBuffer.', ierr)
 
   call clSetKernelArg(kernel, 0, 'e', ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clSetKernelArg.', ierr)
   call clSetKernelArg(kernel, 1, 'a', ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clSetKernelArg.', ierr)
   call clSetKernelArg(kernel, 2, cl_string, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clSetKernelArg.', ierr)
 
   call clGetKernelWorkGroupInfo(kernel, device, CL_KERNEL_WORK_GROUP_SIZE, localsize, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clGetKernelWorkGroupInfo.', ierr)
 
   globalsize = int(string_length, 8)
 
   ! execute the kernel
   call clEnqueueNDRangeKernel(command_queue, kernel, (/globalsize/), (/localsize/), ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueNDRangeKernel.', ierr)
   call clFinish(command_queue, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clFinish.', ierr)
 
   call clEnqueueReadBuffer(command_queue, cl_string, cl_bool(.true.), 0_8, size_in_bytes, string2(1:1), ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueReadBuffer.', ierr)
 
   print*, trim(string2)
 
@@ -74,7 +83,10 @@ program char
   !=====================
 
   call clReleaseKernel(kernel, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseKernel.', ierr)
   call clReleaseCommandQueue(command_queue, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseCommandQueue.', ierr)
   call clReleaseContext(context, ierr)
-  
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseContext.', ierr)
+
 end program char

--- a/testsuite/char.f90
+++ b/testsuite/char.f90
@@ -45,6 +45,9 @@ program char
   cl_string = clCreateBuffer(context, CL_MEM_READ_ONLY, size_in_bytes, ierr)
   if(ierr /= CL_SUCCESS) call error_exit('Error in clCreateBuffer.', ierr)
 
+  call clEnqueueFillBuffer(command_queue, cl_string, ' ', 0_8, size_in_bytes, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueWriteBuffer.', ierr)
+
   string1 = 'Pepper clemens sent the messenger nevertheless the reverend left the herd'
   print*, trim(string1)
 

--- a/testsuite/devices.f90
+++ b/testsuite/devices.f90
@@ -19,6 +19,7 @@
 
 program devs
   use cl
+  use utils
 
   implicit none
 
@@ -30,15 +31,17 @@ program devs
 
   ! get the number of platforms
   call clGetPlatformIDs(num_platforms, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clGetPlatformIDs.', ierr)
 
   allocate(platforms(1:num_platforms))
 
   write(*, '(a,i1)')   'Number of CL platforms      : ', num_platforms
   write(*, '(a)')      ''
 
-  
+
   ! get an array of platforms
   call clGetPlatformIDs(platforms, num_platforms, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clGetPlatformIDs.', ierr)
 
   ! iterate over platforms
   do iplat = 1, num_platforms
@@ -47,17 +50,21 @@ program devs
     write(*, '(a,i1)') 'Platform number             : ', iplat
 
     call clGetPlatformInfo(platforms(iplat), CL_PLATFORM_VENDOR, info, ierr)
+    if(ierr /= CL_SUCCESS) call error_exit('Error in clGetPlatformInfo.', ierr)
     write(*, '(2a)')   'Vendor                      : ', trim(info)
 
     call clGetPlatformInfo(platforms(iplat), CL_PLATFORM_NAME, info, ierr)
+    if(ierr /= CL_SUCCESS) call error_exit('Error in clGetPlatformInfo.', ierr)
     write(*, '(2a)')   'Name                        : ', trim(info)
 
     call clGetPlatformInfo(platforms(iplat), CL_PLATFORM_VERSION, info, ierr)
+    if(ierr /= CL_SUCCESS) call error_exit('Error in clGetPlatformInfo.', ierr)
     write(*, '(2a)')   'Version                     : ', trim(info)
 
     ! get the device ID
     call clGetDeviceIDs(platforms(iplat), CL_DEVICE_TYPE_ALL, num_devices, ierr)
-  
+    if(ierr /= CL_SUCCESS) call error_exit('Error in clGetDeviceIDs.', ierr)
+
     write(*, '(a,i1)') 'Number of devices           : ', num_devices
     write(*, '(a)')      ''
 
@@ -65,11 +72,13 @@ program devs
 
     ! get the device ID
     call clGetDeviceIDs(platforms(iplat), CL_DEVICE_TYPE_ALL, devices, num_devices, ierr)
-    
+    if(ierr /= CL_SUCCESS) call error_exit('Error in clGetDeviceIDs.', ierr)
+
     do idev = 1, num_devices
       write(*, '(a,i1)') '    Device number           : ', idev
 
       call clGetDeviceInfo(devices(idev), CL_DEVICE_TYPE, val, ierr)
+      if(ierr /= CL_SUCCESS) call error_exit('Error in clGetDeviceInfo.', ierr)
       select case(val)
       case(CL_DEVICE_TYPE_CPU)
         info = 'CPU'
@@ -82,12 +91,15 @@ program devs
       write(*, '(2a)')   '    Device type             : ', trim(info)
 
       call clGetDeviceInfo(devices(idev), CL_DEVICE_VENDOR, info, ierr)
+      if(ierr /= CL_SUCCESS) call error_exit('Error in clGetDeviceInfo.', ierr)
       write(*, '(2a)')   '    Device vendor           : ', trim(info)
 
       call clGetDeviceInfo(devices(idev), CL_DEVICE_NAME, info, ierr)
+      if(ierr /= CL_SUCCESS) call error_exit('Error in clGetDeviceInfo.', ierr)
       write(*, '(2a)')   '    Device name             : ', trim(info)
 
       call clGetDeviceInfo(devices(idev), CL_DEVICE_GLOBAL_MEM_SIZE, val, ierr)
+      if(ierr /= CL_SUCCESS) call error_exit('Error in clGetDeviceInfo.', ierr)
       write(*, '(a,i4)') '    Device memory           : ', val/1024**2
 
       write(*, '(a)')      ''

--- a/testsuite/queue.cl
+++ b/testsuite/queue.cl
@@ -16,7 +16,7 @@
 ** $Id$
 **/
 
-__kernel void dummy(){
+__kernel void dummy(int foo){
 
 }
 

--- a/testsuite/queue.f90
+++ b/testsuite/queue.f90
@@ -36,51 +36,55 @@ program queue
   call initialize(device, context, command_queue)
 
   call clFinish(command_queue, ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clFinish.')
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clFinish.', ierr)
 
   call clFlush(command_queue, ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clFlush.')
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clFlush.', ierr)
 
   call build_kernel('queue.cl', 'dummy', context, device, kernel)
 
   ! get the localsize for the kernel (note that the sizes are integer(8) variable)
   call clGetKernelWorkGroupInfo(kernel, device, CL_KERNEL_WORK_GROUP_SIZE, localsize, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clGetKernelWorkGroupInfo.', ierr)
   globalsize = 1024_8*localsize
 
   ! execute the kernel
   call clEnqueueNDRangeKernel(command_queue, kernel, (/globalsize/), (/localsize/), event, ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueNDRangeKernel.')
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueNDRangeKernel.', ierr)
 
   call clFinish(command_queue, ierr)
-  
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clFinish.', ierr)
+
   call clWaitForEvents(event, ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clWaitForEvents.')
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clWaitForEvents.', ierr)
 
   call clRetainEvent(event, ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clRetainEvent.')
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clRetainEvent.', ierr)
   call clReleaseEvent(event, ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseEvent.')
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseEvent.', ierr)
   call clReleaseEvent(event, ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseEvent.')
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseEvent.', ierr)
 
   ! execute the kernel
   call clEnqueueNDRangeKernel(command_queue, kernel, (/globalsize/), (/localsize/), events(1), ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueNDRangeKernel.')
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueNDRangeKernel.', ierr)
 
   call clEnqueueNDRangeKernel(command_queue, kernel, (/globalsize/), (/localsize/), events(2), ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueNDRangeKernel.')
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueNDRangeKernel.', ierr)
 
   call clWaitForEvents(events, ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clWaitForEvents.')
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clWaitForEvents.', ierr)
 
   call clReleaseEvent(events(1), ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseEvent.')
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseEvent.', ierr)
 
   call clReleaseEvent(events(2), ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseEvent.')
-
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseEvent.', ierr)
 
   call clReleaseCommandQueue(command_queue, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseCommandQueue.', ierr)
+
   call clReleaseContext(context, ierr)
-  
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseContext.', ierr)
+
 end program queue

--- a/testsuite/queue.f90
+++ b/testsuite/queue.f90
@@ -27,7 +27,7 @@ program queue
   type(cl_context)       :: context
   type(cl_command_queue) :: command_queue
   type(cl_kernel)        :: kernel
-  type(cl_event)         :: event, events(1:2)
+  type(cl_event)         :: event(1), events(1:2)
   integer    :: size, ierr
   integer(8) :: size_in_bytes, globalsize, localsize
   type(cl_mem)        :: cl_string
@@ -49,7 +49,7 @@ program queue
   globalsize = 1024_8*localsize
 
   ! execute the kernel
-  call clEnqueueNDRangeKernel(command_queue, kernel, (/globalsize/), (/localsize/), event, ierr)
+  call clEnqueueNDRangeKernel(command_queue, kernel, (/globalsize/), (/localsize/), event(1), ierr)
   if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueNDRangeKernel.', ierr)
 
   call clFinish(command_queue, ierr)
@@ -58,11 +58,9 @@ program queue
   call clWaitForEvents(event, ierr)
   if(ierr /= CL_SUCCESS) call error_exit('Error in clWaitForEvents.', ierr)
 
-  call clRetainEvent(event, ierr)
+  call clRetainEvent(event(1), ierr)
   if(ierr /= CL_SUCCESS) call error_exit('Error in clRetainEvent.', ierr)
-  call clReleaseEvent(event, ierr)
-  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseEvent.', ierr)
-  call clReleaseEvent(event, ierr)
+  call clReleaseEvent(event(1), ierr)
   if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseEvent.', ierr)
 
   ! execute the kernel

--- a/testsuite/queue.f90
+++ b/testsuite/queue.f90
@@ -43,6 +43,9 @@ program queue
 
   call build_kernel('queue.cl', 'dummy', context, device, kernel)
 
+  call clSetKernelArg(kernel, 0, 1729, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clSetKernelArg.', ierr)
+
   ! get the localsize for the kernel (note that the sizes are integer(8) variable)
   call clGetKernelWorkGroupInfo(kernel, device, CL_KERNEL_WORK_GROUP_SIZE, localsize, ierr)
   if(ierr /= CL_SUCCESS) call error_exit('Error in clGetKernelWorkGroupInfo.', ierr)

--- a/testsuite/queue.f90
+++ b/testsuite/queue.f90
@@ -27,11 +27,15 @@ program queue
   type(cl_context)       :: context
   type(cl_command_queue) :: command_queue
   type(cl_kernel)        :: kernel
-  type(cl_event)         :: event(1), events(1:2)
+  type(cl_event)         :: event, events(1:2)
   integer    :: size, ierr
   integer(8) :: size_in_bytes, globalsize, localsize
   type(cl_mem)        :: cl_string
   integer, parameter  :: string_length = 1024
+
+  event = transfer(1337_8, event)
+  events(1) = transfer(1729_8, events(1))
+  events(2) = transfer(2137_8, events(2))
 
   call initialize(device, context, command_queue)
 
@@ -52,7 +56,7 @@ program queue
   globalsize = 1024_8*localsize
 
   ! execute the kernel
-  call clEnqueueNDRangeKernel(command_queue, kernel, (/globalsize/), (/localsize/), event(1), ierr)
+  call clEnqueueNDRangeKernel(command_queue, kernel, (/globalsize/), (/localsize/), event, ierr)
   if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueNDRangeKernel.', ierr)
 
   call clFinish(command_queue, ierr)
@@ -61,9 +65,9 @@ program queue
   call clWaitForEvents(event, ierr)
   if(ierr /= CL_SUCCESS) call error_exit('Error in clWaitForEvents.', ierr)
 
-  call clRetainEvent(event(1), ierr)
+  call clRetainEvent(event, ierr)
   if(ierr /= CL_SUCCESS) call error_exit('Error in clRetainEvent.', ierr)
-  call clReleaseEvent(event(1), ierr)
+  call clReleaseEvent(event, ierr)
   if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseEvent.', ierr)
 
   ! execute the kernel

--- a/testsuite/sum.f90
+++ b/testsuite/sum.f90
@@ -39,12 +39,12 @@ program sum
   !=====================
   ! RUN THE KERNEL
   !=====================
-  
+
   size = 50000
   size_in_bytes = int(size, 8)*4_8
   allocate(vec1(1:size))
   allocate(vec2(1:size))
-  
+
   vec1 = 1.0
   vec2 = 2.0
 
@@ -54,24 +54,33 @@ program sum
 
   ! copy data to device memory
   call clEnqueueWriteBuffer(command_queue, cl_vec1, cl_bool(.true.), 0_8, size_in_bytes, vec1(1), ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueWriteBuffer.', ierr)
   call clEnqueueWriteBuffer(command_queue, cl_vec2, cl_bool(.true.), 0_8, size_in_bytes, vec2(1), ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueWriteBuffer.', ierr)
 
   ! set the kernel arguments
   call clSetKernelArg(kernel, 0, size, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clSetKernelArg.', ierr)
   call clSetKernelArg(kernel, 1, cl_vec1, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clSetKernelArg.', ierr)
   call clSetKernelArg(kernel, 2, cl_vec2, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clSetKernelArg.', ierr)
 
   ! get the localsize for the kernel (note that the sizes are integer(8) variable)
   call clGetKernelWorkGroupInfo(kernel, device, CL_KERNEL_WORK_GROUP_SIZE, localsize, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clGetKernelWorkGroupInfo.', ierr)
   globalsize = int(size, 8)
   if(mod(globalsize, localsize) /= 0) globalsize = globalsize + localsize - mod(globalsize, localsize) 
 
   ! execute the kernel
   call clEnqueueNDRangeKernel(command_queue, kernel, (/globalsize/), (/localsize/), ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueNDRangeKernel.', ierr)
   call clFinish(command_queue, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clFinish.', ierr)
 
   ! read the resulting vector from device memory
   call clEnqueueReadBuffer(command_queue, cl_vec2, cl_bool(.true.), 0_8, size_in_bytes, vec2(1), ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueReadBuffer.', ierr)
 
   if(any(abs(vec2 - 3.0) > epsilon(3.0))) call error_exit('Wrong result')
 
@@ -80,7 +89,10 @@ program sum
   !=====================
 
   call clReleaseKernel(kernel, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseKernel.', ierr)
   call clReleaseCommandQueue(command_queue, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseCommandQueue.', ierr)
   call clReleaseContext(context, ierr)
+  if(ierr /= CL_SUCCESS) call error_exit('Error in clReleaseContext.', ierr)
 
 end program sum

--- a/testsuite/sum.f90
+++ b/testsuite/sum.f90
@@ -52,6 +52,11 @@ program sum
   cl_vec1 = clCreateBuffer(context, CL_MEM_READ_ONLY, size_in_bytes, ierr)
   cl_vec2 = clCreateBuffer(context, CL_MEM_READ_WRITE, size_in_bytes, ierr)
 
+ call clEnqueueFillBuffer(command_queue, cl_vec1, 0.0, 0_8, size_in_bytes, ierr)
+ if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueFillBuffer.', ierr)
+ call clEnqueueFillBuffer(command_queue, cl_vec2, 0.0, 0_8, size_in_bytes, ierr)
+ if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueFillBuffer.', ierr)
+
   ! copy data to device memory
   call clEnqueueWriteBuffer(command_queue, cl_vec1, cl_bool(.true.), 0_8, size_in_bytes, vec1(1), ierr)
   if(ierr /= CL_SUCCESS) call error_exit('Error in clEnqueueWriteBuffer.', ierr)


### PR DESCRIPTION
Since GCC10, mismatches between actual and dummy argument lists in a single file are now rejected with an error.

> * Mismatches between actual and dummy argument lists in a single file are now rejected with an error. Use the new option `-fallow-argument-mismatch` to turn these errors into warnings; this option is implied with `-std=legacy`. `-Wargument-mismatch` has been removed.

 https://gcc.gnu.org/gcc-10/changes.html#fortran

While I was at it I also thought I could quickly set up GitHub Actions for continuous integration. However, in doing that I found a number of bugs that I fixed or worked around somewhat.